### PR TITLE
Make material recreators run explicitly

### DIFF
--- a/scripts/generate_usd_artifacts.py
+++ b/scripts/generate_usd_artifacts.py
@@ -89,7 +89,7 @@ def _convert(conv: dict, out_dir: Path) -> Path:
             nodeinfo_list=nodeinfo_list,
             output_connections=output_connections,
             target_renderer=conv["target_renderer"],
-        )
+        ).run()
 
     stage.Save()
     return out_path

--- a/src/materials_processor/houdini/commands.py
+++ b/src/materials_processor/houdini/commands.py
@@ -98,6 +98,7 @@ def run(input_material_builder_node, target_context, target_format='arnold'):
             target_context=target_context,
             target_renderer=target_format
         )
+        recreator.run()
         logger.info("NodeRecreator() Finished----------------------")
         logger.info("Material conversion complete. Converted material from '%s' to '%s'.", material_type, target_format)
     except Exception:
@@ -173,6 +174,7 @@ def convert_material_from_opmenu(kwargs):
                 target_renderer=target_format,
                 material_name=input_material_builder_node.name(),
             )
+            recreator.run()
             logger.info("NodeRecreator() Finished----------------------")
             logger.info("Material conversion complete. Converted material from '%s' to '%s'.", material_type, target_format)
         except Exception:
@@ -224,6 +226,7 @@ def test_hou():
             target_context=target_context,
             target_renderer=target_renderer
         )
+        recreator.run()
     except Exception:
         traceback.print_exc()
         return

--- a/src/materials_processor/houdini/recreator.py
+++ b/src/materials_processor/houdini/recreator.py
@@ -66,9 +66,6 @@ class NodeRecreator:
         #                                                   }
         #                                               }
 
-        self.run()
-
-
     @staticmethod
     def create_mtlx_init_shader(matnet=None, material_name=None):
         """

--- a/src/materials_processor/usd/commands.py
+++ b/src/materials_processor/usd/commands.py
@@ -63,7 +63,13 @@ def test(stage, mat_node, target_renderer="mtlx"):
     """
 
     try:
-        USDMaterialRecreator(stage, mat_node.name(), nodeinfo_list, output_connections, target_renderer=target_renderer)
+        USDMaterialRecreator(
+            stage,
+            mat_node.name(),
+            nodeinfo_list,
+            output_connections,
+            target_renderer=target_renderer,
+        ).run()
     except Exception:
         logger.exception("Exception in test")
 
@@ -148,8 +154,13 @@ def test2(stage, usd_material, target_renderer="arnold"):
     nodeinfo_list, output_connections = standardizer.run()
 
     try:
-        USDMaterialRecreator(stage, "__material", nodeinfo_list, output_connections,
-                             target_renderer=target_renderer)
+        USDMaterialRecreator(
+            stage,
+            "__material",
+            nodeinfo_list,
+            output_connections,
+            target_renderer=target_renderer,
+        ).run()
     except Exception:
         logger.exception("Exception in test2")
 

--- a/src/materials_processor/usd/recreator.py
+++ b/src/materials_processor/usd/recreator.py
@@ -18,7 +18,7 @@ class USDMaterialRecreator:
         parent_scope_path: str = "/materials",
         target_renderer: str = "arnold",
     ):
-        """Initialize and immediately run the network rebuild."""
+        """Initialize the recreator with material data and target stage."""
         self.stage = stage
         self.material_name = material_name
         self.nodeinfo_list = nodeinfo_list
@@ -36,8 +36,6 @@ class USDMaterialRecreator:
         self.material_map = self.graph_builder.material_map
         self.old_new_map = self.graph_builder.old_new_map
         self.created_out_primpaths = self.graph_builder.created_out_primpaths
-
-        self.run()
 
     def create_material_prim(self):
         """Define output material prims for the standardized graph."""

--- a/tests/test_material_processor_runtime.py
+++ b/tests/test_material_processor_runtime.py
@@ -2,6 +2,7 @@ import copy
 
 from materials_processor import io, mappings, standardizer
 from materials_processor.houdini import commands, traverser
+from materials_processor.houdini.recreator import NodeRecreator
 
 
 class FakeNodeType:
@@ -119,6 +120,8 @@ def test_opmenu_renderer_filter_does_not_mutate_global_format_choices(monkeypatc
         pass
 
     class FakeRecreator:
+        was_run = False
+
         def __init__(
             self,
             nodeinfo_list,
@@ -128,6 +131,9 @@ def test_opmenu_renderer_filter_does_not_mutate_global_format_choices(monkeypatc
             material_name,
         ):
             created_renderers.append(target_renderer)
+
+        def run(self):
+            self.__class__.was_run = True
 
     monkeypatch.delenv("HTOA", raising=False)
     monkeypatch.delenv("REDSHIFT_COREDATAPATH", raising=False)
@@ -144,7 +150,20 @@ def test_opmenu_renderer_filter_does_not_mutate_global_format_choices(monkeypatc
 
     assert displayed_buttons == ["Principled Shader", "MTLX", "Cancel"]
     assert created_renderers == ["mtlx"]
+    assert FakeRecreator.was_run
     assert mappings.FORMAT_CHOICES == original_choices
+
+
+def test_houdini_recreator_constructor_does_not_run():
+    recreator = NodeRecreator(
+        nodeinfo_list=[],
+        output_connections={},
+        target_context=object(),
+        target_renderer="arnold",
+    )
+
+    assert recreator.material_node is None
+    assert recreator.new_output_connections == {}
 
 
 def test_setup_file_logging_configures_file_logger_safely(tmp_path):

--- a/tests/test_usd_json_conversion.py
+++ b/tests/test_usd_json_conversion.py
@@ -178,7 +178,7 @@ def _build_usd_stage_from_houdini_json(fixture, target_renderer):
             nodeinfo_list=nodeinfo_list,
             output_connections=output_connections,
             target_renderer=target_renderer,
-        )
+        ).run()
 
     return stage
 
@@ -262,3 +262,22 @@ def test_usd_recreator_legacy_texture_collect_builder_smoke():
     assert stage.GetPrimAtPath(
         "/texture_smoke/mat_smoke_glass_collect/UsdPreviewMaterial/UsdPreviewNodeGraph/UsdPreviewSurface"
     ).IsValid()
+
+
+def test_usd_recreator_constructor_does_not_create_material_until_run():
+    nodeinfo_list, output_connections = _load_houdini_fixture(HOUDINI_MTLX_FULL)
+    stage = Usd.Stage.CreateInMemory()
+
+    recreator = USDMaterialRecreator(
+        stage=stage,
+        material_name=HOUDINI_MTLX_FULL.material_name,
+        nodeinfo_list=nodeinfo_list,
+        output_connections=output_connections,
+        target_renderer="mtlx",
+    )
+
+    assert not stage.GetPrimAtPath(HOUDINI_MTLX_FULL.material_path).IsValid()
+
+    recreator.run()
+
+    assert stage.GetPrimAtPath(HOUDINI_MTLX_FULL.material_path).IsValid()


### PR DESCRIPTION
## Summary
- remove constructor-side `run()` calls from Houdini and USD material recreators
- update command/script callers to invoke `.run()` explicitly
- add regression tests for constructor-only setup behavior

## Validation
- `uv --native-tls run pytest`
