### PR TITLE
Add typed graph connection models

### DIFF
--- a/src/materials_processor/houdini/recreator.py
+++ b/src/materials_processor/houdini/recreator.py
@@ -267,7 +267,7 @@ class NodeRecreator:
             logger.debug("PrincipledShader does not require explicit output nodes. Skipping creation.")
             return
 
-        for generic_output_type, output_info in self.orig_output_connections.items():
+        for generic_output_type, output_connection in self.orig_output_connections.items():
             # e.g. generic_output_type = "GENERIC::output_surface"
             # e.g. output_info         = {'node_path': '/mat/material_mtlx_ORIG/surface_output',
             #                             'node_name': 'surface_output', ???
@@ -280,19 +280,19 @@ class NodeRecreator:
             created_output_node: hou.VopNode = hou.node(new_output_nodepath)
 
 
-            self.old_new_node_map[output_info['node_path']] = {'node_name': created_output_node.name(),
-                                                               'node_path': created_output_node.path(),
-                                                               'is_output': True,
-                                                               'output_type': generic_output_type,
-                                                               }
+            self.old_new_node_map[output_connection.node_path] = {'node_name': created_output_node.name(),
+                                                                  'node_path': created_output_node.path(),
+                                                                  'is_output': True,
+                                                                  'output_type': generic_output_type,
+                                                                  }
 
             self.new_output_connections[generic_output_type] = {'node': created_output_node,
                                                                 'node_name': created_output_node.name(),
                                                                 'node_path': created_output_node.path(),
-                                                                'connected_node_name': output_info['connected_node_name'],
-                                                                'connected_input_index': output_info['connected_input_index'],
-                                                                'connected_input_name': output_info['connected_input_name'],
-                                                                'connected_output_name': output_info['connected_output_name'],
+                                                                'connected_node_name': output_connection.connected_node_name,
+                                                                'connected_input_index': output_connection.connected_input_index,
+                                                                'connected_input_name': output_connection.connected_input_name,
+                                                                'connected_output_name': output_connection.connected_output_name,
                                                                 }
         return None
 
@@ -557,13 +557,13 @@ class NodeRecreator:
         """
         for conn in src_nodeinfo.connection_info.values():
             # print(f"DEBUG: ///conn: {pprint.pformat(conn, sort_dicts=False)}")
-            logger.debug("connecting src node: '%s[%s][%s]' to dest node: '%s[%s][%s]'", src_nodeinfo.node_name, conn['input']['node_index'], conn['input']['parm_name'], dest_node.name(), conn['output']['node_index'], conn['output']['parm_name'])
-            src_node_name = conn['input']['node_name']
-            src_parm_name = conn['input']['parm_name']
-            dest_node_name = conn['output']['node_name']
-            dest_parm_name = conn['output']['parm_name']
+            logger.debug("connecting src node: '%s[%s][%s]' to dest node: '%s[%s][%s]'", src_nodeinfo.node_name, conn.input.node_index, conn.input.parm_name, dest_node.name(), conn.output.node_index, conn.output.parm_name)
+            src_node_name = conn.input.node_name
+            src_parm_name = conn.input.parm_name
+            dest_node_name = conn.output.node_name
+            dest_parm_name = conn.output.parm_name
             dest_node_type = dest_node.type().name()
-            src_node_type  = conn['input']['node_type']
+            src_node_type = conn.input.node_type
 
             # find the source (input) node
             src_node = self._get_input_node(src_node_name)

--- a/src/materials_processor/models.py
+++ b/src/materials_processor/models.py
@@ -3,8 +3,170 @@ copyright Ahmed Hindy. Please mention the original author if you used any part o
 This module processes material nodes in Houdini, standardizing shader nodes and parameters.
 """
 import pprint
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class ConnectionEndpoint(Mapping):
+    """Identifies one side of a node-to-node connection."""
+
+    node_name: str
+    node_path: str
+    node_type: str
+    node_index: Optional[int]
+    parm_name: str
+    data_type: Optional[str] = None
+
+    @classmethod
+    def from_mapping(cls, endpoint: Mapping[str, Any]) -> "ConnectionEndpoint":
+        """Create a typed endpoint from traverser dictionary data."""
+        return cls(
+            node_name=endpoint["node_name"],
+            node_path=endpoint["node_path"],
+            node_type=endpoint["node_type"],
+            node_index=endpoint.get("node_index"),
+            parm_name=endpoint["parm_name"],
+            data_type=endpoint.get("data_type"),
+        )
+
+    def with_parm_name(self, parm_name: str) -> "ConnectionEndpoint":
+        """Return a copy of this endpoint with a standardized parameter name."""
+        return ConnectionEndpoint(
+            node_name=self.node_name,
+            node_path=self.node_path,
+            node_type=self.node_type,
+            node_index=self.node_index,
+            parm_name=parm_name,
+            data_type=self.data_type,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the legacy JSON-compatible endpoint representation."""
+        endpoint = {
+            "node_name": self.node_name,
+            "node_path": self.node_path,
+            "node_type": self.node_type,
+            "node_index": self.node_index,
+            "parm_name": self.parm_name,
+        }
+        if self.data_type is not None:
+            endpoint["data_type"] = self.data_type
+        return endpoint
+
+    def __getitem__(self, key):
+        return self.to_dict()[key]
+
+    def __iter__(self):
+        return iter(self.to_dict())
+
+    def __len__(self):
+        return len(self.to_dict())
+
+    def __eq__(self, other):
+        if isinstance(other, ConnectionEndpoint):
+            return self.to_dict() == other.to_dict()
+        if isinstance(other, Mapping):
+            return self.to_dict() == dict(other)
+        return super().__eq__(other)
+
+
+@dataclass(frozen=True)
+class NodeConnection(Mapping):
+    """A typed connection between an upstream input endpoint and downstream output endpoint."""
+
+    input: ConnectionEndpoint
+    output: ConnectionEndpoint
+
+    @classmethod
+    def from_mapping(cls, connection: Mapping[str, Mapping[str, Any]]) -> "NodeConnection":
+        """Create a typed node connection from traverser dictionary data."""
+        return cls(
+            input=ConnectionEndpoint.from_mapping(connection["input"]),
+            output=ConnectionEndpoint.from_mapping(connection["output"]),
+        )
+
+    def to_dict(self) -> dict[str, dict[str, Any]]:
+        """Return the legacy JSON-compatible connection representation."""
+        return {
+            "input": self.input.to_dict(),
+            "output": self.output.to_dict(),
+        }
+
+    def __getitem__(self, key):
+        if key == "input":
+            return self.input
+        if key == "output":
+            return self.output
+        raise KeyError(key)
+
+    def __iter__(self):
+        return iter(("input", "output"))
+
+    def __len__(self):
+        return 2
+
+    def __eq__(self, other):
+        if isinstance(other, NodeConnection):
+            return self.to_dict() == other.to_dict()
+        if isinstance(other, Mapping):
+            return self.to_dict() == dict(other)
+        return super().__eq__(other)
+
+
+@dataclass(frozen=True)
+class OutputConnection(Mapping):
+    """Connection metadata for one material output slot."""
+
+    node_name: str
+    node_path: str
+    connected_node_name: str
+    connected_node_path: str
+    connected_input_index: Optional[int]
+    connected_input_name: str
+    connected_output_name: str
+
+    @classmethod
+    def from_mapping(cls, output_connection: Mapping[str, Any]) -> "OutputConnection":
+        """Create a typed output connection from traverser dictionary data."""
+        return cls(
+            node_name=output_connection["node_name"],
+            node_path=output_connection["node_path"],
+            connected_node_name=output_connection["connected_node_name"],
+            connected_node_path=output_connection["connected_node_path"],
+            connected_input_index=output_connection.get("connected_input_index"),
+            connected_input_name=output_connection["connected_input_name"],
+            connected_output_name=output_connection["connected_output_name"],
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the legacy JSON-compatible output connection representation."""
+        return {
+            "node_name": self.node_name,
+            "node_path": self.node_path,
+            "connected_node_name": self.connected_node_name,
+            "connected_node_path": self.connected_node_path,
+            "connected_input_index": self.connected_input_index,
+            "connected_input_name": self.connected_input_name,
+            "connected_output_name": self.connected_output_name,
+        }
+
+    def __getitem__(self, key):
+        return self.to_dict()[key]
+
+    def __iter__(self):
+        return iter(self.to_dict())
+
+    def __len__(self):
+        return len(self.to_dict())
+
+    def __eq__(self, other):
+        if isinstance(other, OutputConnection):
+            return self.to_dict() == other.to_dict()
+        if isinstance(other, Mapping):
+            return self.to_dict() == dict(other)
+        return super().__eq__(other)
 
 
 @dataclass
@@ -19,7 +181,7 @@ class NodeParameter:
     generic_name: Optional[str] = None
     generic_type: Optional[str] = None
     direction: Optional[str] = None  # 'input' or 'output'
-    value: Optional[any] = None
+    value: Optional[Any] = None
 
     def __repr__(self):
         return f"NodeParameter(generic_name={self.generic_name}, value={self.value})"
@@ -35,7 +197,7 @@ class NodeInfo:
         node_name (str): The name of the node.
         node_path (str): The path for the node.
         parameters (List[NodeParameter]): A list of parameters associated with the node.
-        connection_info: (dict[str, dict[str, Any]]): a dictionary for node connection information.
+        connection_info (dict[str, NodeConnection]): Node connection information keyed by connection id.
         children_list (List['NodeInfo']): A list of child nodes connected to this node.
         is_output_node (bool): Whether this node is an output node.
         output_type (Optional[str]): The type of output, e.g., 'surface', 'displacement', etc.
@@ -45,7 +207,7 @@ class NodeInfo:
     node_name: str
     node_path: str
     parameters: List[NodeParameter]
-    connection_info: dict[str, dict[str, Any]] = field(default_factory=dict)  # {"input": {"index": int, "parm": str}, "output": {...}}
+    connection_info: dict[str, NodeConnection] = field(default_factory=dict)
     children_list: list['NodeInfo'] = field(default_factory=list)
     is_output_node: bool = False
     output_type: Optional[str] = None
@@ -78,12 +240,12 @@ class MaterialData:
         material_name (str): The name of the material.
         material_path (Optional[str]): The path to the material within the network.
         nodeinfo_list (List[NodeInfo]): A list of nodes that make up the material network.
-        output_connections (Dict[str, Optional[NodeInfo]]): A dictionary of output connections for the material.
+        output_connections (Dict[str, OutputConnection]): A dictionary of output connections for the material.
     """
     material_name: str
     material_path: Optional[str] = None
     nodeinfo_list: List[NodeInfo] = field(default_factory=list)
-    output_connections: Dict[str, NodeInfo] = field(default_factory=dict)  # Add this line
+    output_connections: Dict[str, OutputConnection] = field(default_factory=dict)
 
     def __str__(self):
         return self._pretty_print()

--- a/src/materials_processor/standardizer.py
+++ b/src/materials_processor/standardizer.py
@@ -11,7 +11,7 @@ from materials_processor.mappings import (
     REGULAR_PARAM_NAMES_TO_GENERIC,
     STANDARDIZER_SUPPORTED_SOURCE_TYPES,
 )
-from materials_processor.models import NodeInfo, NodeParameter
+from materials_processor.models import ConnectionEndpoint, NodeConnection, NodeInfo, NodeParameter, OutputConnection
 
 logger = logging.getLogger(__name__)
 
@@ -65,15 +65,7 @@ class NodeStandardizer:
         output_connections = {}
         for key, value in output_nodes_dict.items():
             standardized_key = f"GENERIC::output_{key}"
-            output_connections[standardized_key] = {
-                'node_name': value['node_name'],
-                'node_path': value['node_path'],
-                'connected_node_name': value['connected_node_name'],
-                'connected_node_path': value['connected_node_path'],
-                'connected_input_index': value.get('connected_input_index'),
-                'connected_input_name': value['connected_input_name'],
-                'connected_output_name': value['connected_output_name'],
-            }
+            output_connections[standardized_key] = OutputConnection.from_mapping(value)
         return output_connections
 
 
@@ -180,27 +172,34 @@ class NodeStandardizer:
         new_connections_dict = {}
 
         for i, connection_dict in connections_dict.items():
-            new_connections_dict[i] = connection_dict
-            for direction, direction_dict in connection_dict.items():
-                new_connections_dict[i][direction] = direction_dict
+            connection = NodeConnection.from_mapping(connection_dict)
+            endpoints = {}
+            for direction in connection:
+                endpoint: ConnectionEndpoint = connection[direction]
 
-                node_type = direction_dict['node_type']
+                node_type = endpoint.node_type
                 generic_parm_names_dict = REGULAR_PARAM_NAMES_TO_GENERIC.get(node_type.replace('::', ':'))
                 if not generic_parm_names_dict:
                     logger.warning("No generic parameters mapping was found for nodetype: '%s'.", node_type)
                     _parms_with_no_mapping.append(node_type)
+                    endpoints[direction] = endpoint
                     continue
 
-                param = direction_dict['parm_name']
+                param = endpoint.parm_name
                 generic_name = generic_parm_names_dict.get(param, None)
                 if not generic_name:
                     logger.warning("No generic name was found for parameter: '%s' for node_type: '%s'", param, node_type)
                     _unsupported_parms_list.append(param)
                     _parms_with_no_generic_name_list.append(param)
                     # logger.debug("generic_parm_names_dict: %s", pprint.pformat(generic_parm_names_dict, sort_dicts=False))
+                    endpoints[direction] = endpoint
                     continue
-                new_connections_dict[i][direction]['parm_name'] = generic_name
+                endpoints[direction] = endpoint.with_parm_name(generic_name)
 
+            new_connections_dict[i] = NodeConnection(
+                input=endpoints["input"],
+                output=endpoints["output"],
+            )
 
         return new_connections_dict
 

--- a/src/materials_processor/usd/graph_builder.py
+++ b/src/materials_processor/usd/graph_builder.py
@@ -108,13 +108,13 @@ class USDGraphBuilder:
 
         Populates self.old_new_map for each Houdini output node.
         """
-        for out_dict in self.orig_output_connections.values():
+        for output_connection in self.orig_output_connections.values():
             mat_primname = self.material_name
             mat_primpath = Sdf.Path(f"{self.parent_scope_path}/{mat_primname}")
             UsdShade.Material.Define(self.stage, Sdf.Path(mat_primpath))
 
             self.created_out_primpaths.append(mat_primpath)
-            self.old_new_map[out_dict['node_path']] = mat_primpath.pathString
+            self.old_new_map[output_connection.node_path] = mat_primpath.pathString
 
 
     def create_child_shaders(self, nodeinfo_list):
@@ -155,9 +155,9 @@ class USDGraphBuilder:
         mat_usdshade = UsdShade.Material.Get(self.stage, mat_primpath)
 
         logger.debug("self.created_out_primpaths: %s", pprint.pformat(self.created_out_primpaths, sort_dicts=False))
-        for generic_output, out_dict in self.orig_output_connections.items():
-            src_path = self.old_new_map[out_dict['connected_node_path']]
-            dst_path = self.old_new_map[out_dict['node_path']]
+        for generic_output, output_connection in self.orig_output_connections.items():
+            src_path = self.old_new_map[output_connection.connected_node_path]
+            dst_path = self.old_new_map[output_connection.node_path]
             if dst_path not in [x.pathString for x in self.created_out_primpaths]:
                 continue
 
@@ -177,20 +177,20 @@ class USDGraphBuilder:
         if parent_nodeinfo:
             logger.debug("parent: '%s'", parent_nodeinfo.node_path)
         for conn_index, conn in nodeinfo.connection_info.items():
-            logger.debug("node: parent node_path: '%s'", conn['output']['node_path'])
-            if parent_nodeinfo and conn['output']['node_path'] != parent_nodeinfo.node_path:
+            logger.debug("node: parent node_path: '%s'", conn.output.node_path)
+            if parent_nodeinfo and conn.output.node_path != parent_nodeinfo.node_path:
                 logger.debug("Invalid parent, skipping connection!")
                 continue
 
-            logger.debug("node: %s -> %s", conn['input']['parm_name'], conn['output']['parm_name'])
+            logger.debug("node: %s -> %s", conn.input.parm_name, conn.output.parm_name)
             for child_nodeinfo in nodeinfo.children_list:
                 child_path = self.old_new_map[child_nodeinfo.node_path]
                 prim = self.stage.GetPrimAtPath(Sdf.Path(child_path))
                 logger.debug("child prim: '%s'", child_path)
                 if prim and prim.GetAttribute('info:id').Get():
                     for c_conn_index, c_conn in child_nodeinfo.connection_info.items():
-                        logger.debug("child: %s -> %s", c_conn['input']['parm_name'], c_conn['output']['parm_name'])
-                        if nodeinfo and c_conn['output']['node_path'] != nodeinfo.node_path:
+                        logger.debug("child: %s -> %s", c_conn.input.parm_name, c_conn.output.parm_name)
+                        if nodeinfo and c_conn.output.node_path != nodeinfo.node_path:
                             logger.debug("Invalid node, skipping connection!")
                             continue
 
@@ -218,10 +218,10 @@ class USDGraphBuilder:
         """
         for nodeinfo in nodeinfo_list:
             for conn_index, conn in nodeinfo.connection_info.items():
-                src_path = self.old_new_map.get(conn['input']['node_path'])
-                dst_path = self.old_new_map.get(conn['output']['node_path'])
-                src_parm = conn['input']['parm_name']
-                dst_parm = conn['output']['parm_name']
+                src_path = self.old_new_map.get(conn.input.node_path)
+                dst_path = self.old_new_map.get(conn.output.node_path)
+                src_parm = conn.input.parm_name
+                dst_parm = conn.output.parm_name
                 src_prim = self.stage.GetPrimAtPath(Sdf.Path(src_path)) if src_path else None
                 dst_prim = self.stage.GetPrimAtPath(Sdf.Path(dst_path)) if dst_path else None
 
@@ -245,7 +245,7 @@ class USDGraphBuilder:
 
                     logger.debug("new_src_prim=%s", new_src_prim)
                     logger.debug("new_conn: %s", pprint.pformat(new_conn, sort_dicts=False))
-                    self._connect_pair(new_src_prim, dst_prim, new_conn['input']['parm_name'], dst_parm)
+                    self._connect_pair(new_src_prim, dst_prim, new_conn.input.parm_name, dst_parm)
                     continue
 
 

--- a/tests/test_material_processor_runtime.py
+++ b/tests/test_material_processor_runtime.py
@@ -3,6 +3,7 @@ import copy
 from materials_processor import io, mappings, standardizer
 from materials_processor.houdini import commands, traverser
 from materials_processor.houdini.recreator import NodeRecreator
+from materials_processor.models import NodeConnection, OutputConnection
 
 
 class FakeNodeType:
@@ -54,7 +55,7 @@ def test_material_processor_test_helper_uses_checked_in_fixtures(tmp_path, monke
     nodeinfo_list, output_connections = commands.test()
 
     assert nodeinfo_list
-    assert output_connections == {
+    assert {key: value.to_dict() for key, value in output_connections.items()} == {
         "GENERIC::output_surface": {
             "node_name": "surface_output",
             "node_path": "/mat/mtlxmaterial_full/surface_output",
@@ -96,9 +97,19 @@ def test_standardizer_preserves_runtime_connection_mapping(tmp_path, monkeypatch
         "GENERIC::output_node",
         "GENERIC::output_node",
     ]
-    assert output_connections["GENERIC::output_surface"]["connected_node_name"] == "mtlxstandard_surface"
+    assert isinstance(output_connections["GENERIC::output_surface"], OutputConnection)
+    assert output_connections["GENERIC::output_surface"].connected_node_name == "mtlxstandard_surface"
     surface_children = nodeinfo_list[0].children_list
     assert any(child.node_type == "GENERIC::standard_surface" for child in surface_children)
+    surface_connection = next(
+        connection
+        for child in surface_children
+        for connection in child.connection_info.values()
+        if isinstance(connection, NodeConnection)
+    )
+    assert surface_connection.input.node_path == "/mat/mtlxmaterial_full/mtlxstandard_surface"
+    assert surface_connection.output.node_path == "/mat/mtlxmaterial_full/surface_output"
+    assert surface_connection.to_dict()["input"]["parm_name"] == "surface"
 
 
 def test_opmenu_renderer_filter_does_not_mutate_global_format_choices(monkeypatch):


### PR DESCRIPTION
## Summary
- Add typed models for graph connection endpoints, node connections, and material output connections.
- Convert traverser dictionaries into typed models at the standardizer boundary.

## Validation
- uv --native-tls run pytest
- uv --native-tls run ruff check