### PR TITLE
[codex] Add hython material fidelity diagnostics

### DIFF
--- a/src/materials_processor/houdini/recreator.py
+++ b/src/materials_processor/houdini/recreator.py
@@ -527,28 +527,8 @@ class NodeRecreator:
                 logger.warning("Ignoring Output connections from input null node: '%s'", new_connected_node_info['node_name'])
                 continue
 
-            source_output_name = new_connected_node_info.get('connected_output_name')
-            source_output_index = 0
-            if source_output_name:
-                resolved_output_index = new_connected_node.outputIndex(source_output_name)
-                if resolved_output_index not in [-1, -999]:
-                    source_output_index = resolved_output_index
-                else:
-                    logger.warning(
-                        "Source node '%s' has no output '%s', using output index 0.",
-                        new_connected_node.path(),
-                        source_output_name,
-                    )
-
-            logger.info(
-                "Setting input for %s[%s] to '%s[%s]' for output type: '%s'",
-                output_node.path(),
-                output_index,
-                new_connected_node.path(),
-                source_output_index,
-                generic_output_type,
-            )
-            output_node.setInput(output_index, new_connected_node, source_output_index)
+            logger.info("Setting input for %s[%s] to '%s[0]' for output type: '%s'", output_node.path(), output_index, new_connected_node.path(), generic_output_type)
+            output_node.setInput(output_index, new_connected_node)
 
         return True
 

--- a/src/materials_processor/houdini/recreator.py
+++ b/src/materials_processor/houdini/recreator.py
@@ -527,8 +527,28 @@ class NodeRecreator:
                 logger.warning("Ignoring Output connections from input null node: '%s'", new_connected_node_info['node_name'])
                 continue
 
-            logger.info("Setting input for %s[%s] to '%s[0]' for output type: '%s'", output_node.path(), output_index, new_connected_node.path(), generic_output_type)
-            output_node.setInput(output_index, new_connected_node)
+            source_output_name = new_connected_node_info.get('connected_output_name')
+            source_output_index = 0
+            if source_output_name:
+                resolved_output_index = new_connected_node.outputIndex(source_output_name)
+                if resolved_output_index not in [-1, -999]:
+                    source_output_index = resolved_output_index
+                else:
+                    logger.warning(
+                        "Source node '%s' has no output '%s', using output index 0.",
+                        new_connected_node.path(),
+                        source_output_name,
+                    )
+
+            logger.info(
+                "Setting input for %s[%s] to '%s[%s]' for output type: '%s'",
+                output_node.path(),
+                output_index,
+                new_connected_node.path(),
+                source_output_index,
+                generic_output_type,
+            )
+            output_node.setInput(output_index, new_connected_node, source_output_index)
 
         return True
 

--- a/tests/test_hython_material_networks.py
+++ b/tests/test_hython_material_networks.py
@@ -18,6 +18,8 @@ DEFAULT_HYTHON = Path(r"C:\Program Files\Side Effects Software\Houdini 21.0.631\
 JSON_START = "===MATERIALS_PROCESSOR_HYTHON_JSON_START==="
 JSON_END = "===MATERIALS_PROCESSOR_HYTHON_JSON_END==="
 TARGET_RENDERERS = list(FORMAT_CHOICES)
+SAME_ENGINE_FIDELITY_TARGETS = ("arnold", "mtlx")
+CROSS_ENGINE_FIDELITY_TARGETS = (("mtlx", "arnold"),)
 EXPECTED_TARGET_NODE_TYPES = {
     "principledshader": "principledshader::2.0",
     "mtlx": "subnet",
@@ -111,13 +113,217 @@ from materials_processor.mappings import FORMAT_CHOICES
 from materials_processor.standardizer import NodeStandardizer
 
 EXPECTED_TARGET_NODE_TYPES = {json.dumps(EXPECTED_TARGET_NODE_TYPES, sort_keys=True)}
+SAME_ENGINE_FIDELITY_TARGETS = {json.dumps(SAME_ENGINE_FIDELITY_TARGETS)}
+CROSS_ENGINE_FIDELITY_TARGETS = {CROSS_ENGINE_FIDELITY_TARGETS!r}
 hou.hipFile.load({str(HIP_FILE)!r}, suppress_save_prompt=True, ignore_load_warnings=True)
 
 mat_context = hou.node("/mat")
 available_node_types = mat_context.childTypeCategory().nodeTypes()
 
+def _normalize_value(value):
+    if isinstance(value, float):
+        return round(value, 6)
+    if isinstance(value, tuple):
+        if len(value) == 1:
+            return _normalize_value(value[0])
+        return [_normalize_value(item) for item in value]
+    if isinstance(value, list):
+        if len(value) == 1:
+            return _normalize_value(value[0])
+        return [_normalize_value(item) for item in value]
+    if isinstance(value, dict):
+        return {{key: _normalize_value(item) for key, item in sorted(value.items())}}
+    return value
+
+def _relative_path(path, root_path):
+    if not path:
+        return path
+    if path == root_path:
+        return "."
+    prefix = root_path + "/"
+    if path.startswith(prefix):
+        return path[len(prefix):]
+    return path
+
+def _parameter_map(parameters):
+    result = {{}}
+    for parameter in parameters or []:
+        if parameter.direction != "input":
+            continue
+        result[parameter.generic_name] = {{
+            "type": parameter.generic_type,
+            "value": _normalize_value(parameter.value),
+        }}
+    return result
+
+def _connection_signature(connection, root_path):
+    return {{
+        "input_node": _relative_path(connection.input.node_path, root_path),
+        "input_name": connection.input.parm_name,
+        "input_type": connection.input.data_type,
+        "output_node": _relative_path(connection.output.node_path, root_path),
+        "output_name": connection.output.parm_name,
+        "output_type": connection.output.data_type,
+    }}
+
+def _output_signature(output_connection, root_path):
+    return {{
+        "node": _relative_path(output_connection.node_path, root_path),
+        "connected_node": _relative_path(output_connection.connected_node_path, root_path),
+        "connected_input": output_connection.connected_input_name,
+        "connected_output": output_connection.connected_output_name,
+    }}
+
+def _fingerprint(nodeinfo_list, output_connections, root_path):
+    nodes = {{}}
+    connections = []
+
+    def walk(nodeinfo):
+        relative_path = _relative_path(nodeinfo.node_path, root_path)
+        node_entry = nodes.setdefault(
+            relative_path,
+            {{
+                "type": nodeinfo.node_type,
+                "parameters": _parameter_map(nodeinfo.parameters),
+            }},
+        )
+        if not node_entry["parameters"] and nodeinfo.parameters:
+            node_entry["parameters"] = _parameter_map(nodeinfo.parameters)
+        for connection in nodeinfo.connection_info.values():
+            connections.append(_connection_signature(connection, root_path))
+        for child_nodeinfo in nodeinfo.children_list:
+            walk(child_nodeinfo)
+
+    for nodeinfo in nodeinfo_list:
+        walk(nodeinfo)
+
+    unique_connections = sorted(
+        {{json.dumps(connection, sort_keys=True) for connection in connections}}
+    )
+    return {{
+        "nodes": nodes,
+        "connections": [json.loads(connection) for connection in unique_connections],
+        "outputs": {{
+            key: _output_signature(value, root_path)
+            for key, value in sorted(output_connections.items())
+        }},
+    }}
+
+def _diff_fingerprints(original, converted):
+    original_nodes = original["nodes"]
+    converted_nodes = converted["nodes"]
+    original_node_paths = set(original_nodes)
+    converted_node_paths = set(converted_nodes)
+    common_node_paths = sorted(original_node_paths & converted_node_paths)
+
+    node_type_mismatches = []
+    parameter_diffs = []
+    for node_path in common_node_paths:
+        if original_nodes[node_path]["type"] != converted_nodes[node_path]["type"]:
+            node_type_mismatches.append({{
+                "node": node_path,
+                "original": original_nodes[node_path]["type"],
+                "converted": converted_nodes[node_path]["type"],
+            }})
+
+        original_parameters = original_nodes[node_path]["parameters"]
+        converted_parameters = converted_nodes[node_path]["parameters"]
+        original_parameter_names = set(original_parameters)
+        converted_parameter_names = set(converted_parameters)
+        missing_parameters = sorted(original_parameter_names - converted_parameter_names)
+        extra_parameters = sorted(converted_parameter_names - original_parameter_names)
+        changed_parameters = []
+        for parameter_name in sorted(original_parameter_names & converted_parameter_names):
+            if original_parameters[parameter_name] != converted_parameters[parameter_name]:
+                changed_parameters.append({{
+                    "parameter": parameter_name,
+                    "original": original_parameters[parameter_name],
+                    "converted": converted_parameters[parameter_name],
+                }})
+        if missing_parameters or extra_parameters or changed_parameters:
+            parameter_diffs.append({{
+                "node": node_path,
+                "missing": missing_parameters,
+                "extra": extra_parameters,
+                "changed": changed_parameters,
+            }})
+
+    original_connections = {{json.dumps(item, sort_keys=True) for item in original["connections"]}}
+    converted_connections = {{json.dumps(item, sort_keys=True) for item in converted["connections"]}}
+    original_outputs = {{key: json.dumps(value, sort_keys=True) for key, value in original["outputs"].items()}}
+    converted_outputs = {{key: json.dumps(value, sort_keys=True) for key, value in converted["outputs"].items()}}
+
+    output_diffs = []
+    for key in sorted(set(original_outputs) | set(converted_outputs)):
+        if original_outputs.get(key) != converted_outputs.get(key):
+            output_diffs.append({{
+                "output": key,
+                "original": json.loads(original_outputs[key]) if key in original_outputs else None,
+                "converted": json.loads(converted_outputs[key]) if key in converted_outputs else None,
+            }})
+
+    return {{
+        "missing_nodes": sorted(original_node_paths - converted_node_paths),
+        "extra_nodes": sorted(converted_node_paths - original_node_paths),
+        "node_type_mismatches": node_type_mismatches,
+        "parameter_diffs": parameter_diffs,
+        "missing_connections": [json.loads(item) for item in sorted(original_connections - converted_connections)],
+        "extra_connections": [json.loads(item) for item in sorted(converted_connections - original_connections)],
+        "output_diffs": output_diffs,
+    }}
+
+def _diff_is_clean(diff):
+    return not any(diff.values())
+
+def _summarize_fidelity(original, converted, diff):
+    original_parameter_count = sum(len(node["parameters"]) for node in original["nodes"].values())
+    missing_parameter_count = sum(len(item["missing"]) for item in diff["parameter_diffs"])
+    changed_parameter_count = sum(len(item["changed"]) for item in diff["parameter_diffs"])
+    return {{
+        "original_node_count": len(original["nodes"]),
+        "converted_node_count": len(converted["nodes"]),
+        "missing_node_count": len(diff["missing_nodes"]),
+        "extra_node_count": len(diff["extra_nodes"]),
+        "original_parameter_count": original_parameter_count,
+        "missing_parameter_count": missing_parameter_count,
+        "changed_parameter_count": changed_parameter_count,
+        "original_connection_count": len(original["connections"]),
+        "converted_connection_count": len(converted["connections"]),
+        "missing_connection_count": len(diff["missing_connections"]),
+        "extra_connection_count": len(diff["extra_connections"]),
+        "output_diff_count": len(diff["output_diffs"]),
+    }}
+
+def _build_fidelity_report(source_path, source_material_type, target_renderer, source_nodeinfo_list, source_output_connections, created_node):
+    converted_material_type = get_material_type(created_node)
+    with contextlib.redirect_stdout(io.StringIO()) as stdout:
+        converted_traversed_nodes, converted_output_nodes = NodeTraverser(created_node, converted_material_type).run()
+        converted_nodeinfo_list, converted_output_connections = NodeStandardizer(
+            traversed_nodes_dict=converted_traversed_nodes,
+            output_nodes_dict=converted_output_nodes,
+            material_type=converted_material_type,
+            source_type="hou_vop_nodes",
+        ).run()
+
+    original = _fingerprint(source_nodeinfo_list, source_output_connections, source_path)
+    converted = _fingerprint(converted_nodeinfo_list, converted_output_connections, created_node.path())
+    diff = _diff_fingerprints(original, converted)
+    return {{
+        "source_path": source_path,
+        "source_material_type": source_material_type,
+        "target_renderer": target_renderer,
+        "created_path": created_node.path(),
+        "created_material_type": converted_material_type,
+        "status": "passed" if _diff_is_clean(diff) else "failed",
+        "summary": _summarize_fidelity(original, converted, diff),
+        "diff": diff,
+        "captured_stdout": stdout.getvalue().splitlines(),
+    }}
+
 ingest_results = {{}}
 conversion_results = []
+fidelity_results = []
+cross_engine_fidelity_results = []
 for node_path in {material_paths}:
     node = hou.node(node_path)
     if node is None:
@@ -201,6 +407,34 @@ for node_path in {material_paths}:
                 case["error"] = "Converted material has no child nodes."
             else:
                 case["status"] = "passed"
+                if material_type == target_renderer and target_renderer in SAME_ENGINE_FIDELITY_TARGETS:
+                    fidelity_report = _build_fidelity_report(
+                        source_path=node_path,
+                        source_material_type=material_type,
+                        target_renderer=target_renderer,
+                        source_nodeinfo_list=nodeinfo_list,
+                        source_output_connections=output_connections,
+                        created_node=created,
+                    )
+                    case["fidelity"] = {{
+                        "status": fidelity_report["status"],
+                        "summary": fidelity_report["summary"],
+                    }}
+                    fidelity_results.append(fidelity_report)
+                if (material_type, target_renderer) in CROSS_ENGINE_FIDELITY_TARGETS:
+                    fidelity_report = _build_fidelity_report(
+                        source_path=node_path,
+                        source_material_type=material_type,
+                        target_renderer=target_renderer,
+                        source_nodeinfo_list=nodeinfo_list,
+                        source_output_connections=output_connections,
+                        created_node=created,
+                    )
+                    case["fidelity"] = {{
+                        "status": fidelity_report["status"],
+                        "summary": fidelity_report["summary"],
+                    }}
+                    cross_engine_fidelity_results.append(fidelity_report)
         except Exception as exc:
             case.update({{
                 "error_type": type(exc).__name__,
@@ -242,6 +476,8 @@ payload = {{
     "target_renderers": list(FORMAT_CHOICES),
     "ingest": ingest_results,
     "conversion": conversion_results,
+    "same_engine_fidelity": fidelity_results,
+    "cross_engine_fidelity": cross_engine_fidelity_results,
     "summary": summary,
 }}
 
@@ -399,3 +635,65 @@ def test_hython_conversion_coverage_summary_has_no_failed_cases(hython_conversio
     assert summary["failed_cases"] == 0, f"{REPORT_PATH}: {summary}"
     assert summary["passed_cases"] == summary["available_cases"]
     assert summary["coverage_percent"] == 100.0
+
+
+@pytest.mark.hython
+def test_hython_same_engine_fidelity_reports_cover_arnold_and_mtlx(hython_conversion_report):
+    fidelity_cases = hython_conversion_report["same_engine_fidelity"]
+
+    assert {
+        (case["source_path"], case["target_renderer"])
+        for case in fidelity_cases
+    } == {
+        ("/mat/arnold_materialbuilder_full", "arnold"),
+        ("/mat/arnold_materialbuilder_basic", "arnold"),
+        ("/mat/mtlxmaterial_full", "mtlx"),
+        ("/mat/mtlxmaterial_basic", "mtlx"),
+    }
+    for case in fidelity_cases:
+        assert case["created_path"]
+        assert case["created_material_type"] == case["target_renderer"]
+        assert case["summary"]["original_node_count"] > 0
+        assert "missing_nodes" in case["diff"]
+        assert "parameter_diffs" in case["diff"]
+
+
+@pytest.mark.hython
+def test_hython_same_engine_fidelity_preserves_all_nodes_parameters_and_connections(hython_conversion_report):
+    failing_cases = [
+        case
+        for case in hython_conversion_report["same_engine_fidelity"]
+        if case["status"] != "passed"
+    ]
+    if failing_cases:
+        pytest.xfail(f"Same-engine fidelity gaps remain; inspect {REPORT_PATH}.")
+
+
+@pytest.mark.hython
+def test_hython_cross_engine_fidelity_reports_cover_mtlx_to_arnold(hython_conversion_report):
+    fidelity_cases = hython_conversion_report["cross_engine_fidelity"]
+
+    assert {
+        (case["source_path"], case["target_renderer"])
+        for case in fidelity_cases
+    } == {
+        ("/mat/mtlxmaterial_full", "arnold"),
+        ("/mat/mtlxmaterial_basic", "arnold"),
+    }
+    for case in fidelity_cases:
+        assert case["created_path"]
+        assert case["created_material_type"] == case["target_renderer"]
+        assert case["summary"]["original_node_count"] > 0
+        assert "missing_nodes" in case["diff"]
+        assert "parameter_diffs" in case["diff"]
+
+
+@pytest.mark.hython
+def test_hython_mtlx_to_arnold_fidelity_preserves_all_nodes_parameters_and_connections(hython_conversion_report):
+    failing_cases = [
+        case
+        for case in hython_conversion_report["cross_engine_fidelity"]
+        if case["status"] != "passed"
+    ]
+    if failing_cases:
+        pytest.xfail(f"MTLX to Arnold fidelity gaps remain; inspect {REPORT_PATH}.")


### PR DESCRIPTION
## Summary

Adds hython-backed material fidelity diagnostics on top of the existing conversion coverage matrix.

- Re-traverses converted Houdini materials and compares normalized generic fingerprints against the original material graph.
- Reports node, parameter, connection, and output diffs in `.pytest_cache/materials_processor/hython_conversion_coverage.json`.
- Covers same-engine fidelity for Arnold -> Arnold and MTLX -> MTLX.
- Adds cross-engine fidelity reporting for MTLX -> Arnold.

## Why

The previous hython matrix could prove that conversion created a target material node, but it could not answer whether the converted material preserved the original graph. These diagnostics make conversion quality visible and provide actionable diffs for remaining gaps.

## Notes

This PR is intentionally test/report only. It does not change runtime conversion logic.

The new fidelity assertions intentionally xfail while known gaps remain:

- Arnold -> Arnold full material currently loses the displacement source output channel (`b` becomes `rgba`).
- Same-engine MTLX basic still has a displacement node name/reuse mismatch.
- MTLX -> Arnold currently creates Arnold materials but is not fidelity-clean. The generated report shows missing displacement output coverage, missing/extra connections, and parameter mapping gaps.

## Validation

- `uv --native-tls run ruff check .`
- `uv --native-tls run pytest tests/test_hython_material_networks.py -m hython`

Latest focused result: `32 passed, 2 xfailed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

- Added fidelity validation testing for material network conversions to ensure conversion quality
- Extended test coverage for both same-engine and cross-engine material conversion scenarios
- Added verification tests to confirm that nodes, parameters, and connections are properly preserved during conversion

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ahmed-Hindy/Materials-Processor/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->